### PR TITLE
Machine readable output kvp-style

### DIFF
--- a/vmtouch.c
+++ b/vmtouch.c
@@ -1064,7 +1064,7 @@ int main(int argc, char **argv) {
         strcpy(pagestr, "Evicted");
       else 
         strcpy(pagestr, "Resident");
-      printf("Files=%" PRId64 " Directories=%" PRId64 " %sPages=%" PRId64 " TotalPages=%" PRId64 " %sSize=%" PRId64 " TotalSize=%" PRId64 " %sPercent=%.3g Elapsed=%.5g", total_files, total_dirs, pagestr, total_pages_in_core, total_pages, pagestr, total_pages_in_core*pagesize, total_pages*pagesize, pagestr, 100.0*total_pages_in_core/total_pages, (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+      printf("Files=%" PRId64 " Directories=%" PRId64 " %sPages=%" PRId64 " TotalPages=%" PRId64 " %sSize=%" PRId64 " TotalSize=%" PRId64 " %sPercent=%.3g Elapsed=%.5g\n", total_files, total_dirs, pagestr, total_pages_in_core, total_pages, pagestr, total_pages_in_core*pagesize, total_pages*pagesize, pagestr, 100.0*total_pages_in_core/total_pages, (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
     }
     else {
       if (o_verbose) printf("\n");

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -1035,6 +1035,11 @@ int main(int argc, char **argv) {
 
   gettimeofday(&end_time, NULL);
 
+  int64_t total_pages_in_core_size = total_pages_in_core * pagesize;
+  int64_t total_pages_size         = total_pages * pagesize;
+  double  total_pages_in_core_perc = 100.0*total_pages_in_core/total_pages;
+  double  elapsed                  = (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0;
+
   if (o_lock || o_lockall) {
     if (o_lockall) {
       if (mlockall(MCL_CURRENT))
@@ -1046,7 +1051,7 @@ int main(int argc, char **argv) {
       write_pidfile();
     }
 
-    if (!o_quiet) printf("LOCKED %" PRId64 " pages (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+    if (!o_quiet) printf("LOCKED %" PRId64 " pages (%s)\n", total_pages, pretty_print_size(total_pages_size));
 
     if (o_wait) reopen_all();
 
@@ -1064,25 +1069,26 @@ int main(int argc, char **argv) {
         strcpy(pagestr, "Evicted");
       else 
         strcpy(pagestr, "Resident");
-      printf("Files=%" PRId64 " Directories=%" PRId64 " %sPages=%" PRId64 " TotalPages=%" PRId64 " %sSize=%" PRId64 " TotalSize=%" PRId64 " %sPercent=%.3g Elapsed=%.5g\n", total_files, total_dirs, pagestr, total_pages_in_core, total_pages, pagestr, total_pages_in_core*pagesize, total_pages*pagesize, pagestr, 100.0*total_pages_in_core/total_pages, (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+      printf("Files=%" PRId64 " Directories=%" PRId64 " %sPages=%" PRId64 " TotalPages=%" PRId64 " %sSize=%" PRId64 " TotalSize=%" PRId64 " %sPercent=%.3g Elapsed=%.5g\n", 
+        total_files, total_dirs, pagestr, total_pages_in_core, total_pages, pagestr, total_pages_in_core_size, total_pages_size, pagestr, total_pages_in_core_perc, elapsed);
     }
     else {
       if (o_verbose) printf("\n");
       printf("           Files: %" PRId64 "\n", total_files);
       printf("     Directories: %" PRId64 "\n", total_dirs);
       if (o_touch)
-        printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+        printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages_size));
       else if (o_evict)
-        printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+        printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages_size));
       else {
         printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
-        printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
-        printf("%s  ", pretty_print_size(total_pages*pagesize));
+        printf("%s/", pretty_print_size(total_pages_in_core_size));
+        printf("%s  ", pretty_print_size(total_pages_size));
         if (total_pages)
-          printf("%.3g%%", 100.0*total_pages_in_core/total_pages);
+          printf("%.3g%%", total_pages_in_core_perc);
         printf("\n");
       }
-      printf("         Elapsed: %.5g seconds\n", (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+      printf("         Elapsed: %.5g seconds\n", elapsed);
     }
   }
 

--- a/vmtouch.c
+++ b/vmtouch.c
@@ -130,6 +130,7 @@ int o_touch=0;
 int o_evict=0;
 int o_quiet=0;
 int o_verbose=0;
+int o_keyvalue=0;
 int o_lock=0;
 int o_lockall=0;
 int o_daemon=0;
@@ -957,13 +958,14 @@ int main(int argc, char **argv) {
 
   pagesize = sysconf(_SC_PAGESIZE);
 
-  while((ch = getopt(argc, argv, "tevqlLdfFh0i:I:p:b:m:P:w")) != -1) {
+  while((ch = getopt(argc, argv, "tevqklLdfFh0i:I:p:b:m:P:w")) != -1) {
     switch(ch) {
       case '?': usage(); break;
       case 't': o_touch = 1; break;
       case 'e': o_evict = 1; break;
       case 'q': o_quiet = 1; break;
       case 'v': o_verbose++; break;
+      case 'k': o_keyvalue = 1; break;
       case 'l': o_lock = 1;
                 o_touch = 1; break;
       case 'L': o_lockall = 1;
@@ -1054,22 +1056,34 @@ int main(int argc, char **argv) {
   }
 
   if (!o_quiet) {
-    if (o_verbose) printf("\n");
-    printf("           Files: %" PRId64 "\n", total_files);
-    printf("     Directories: %" PRId64 "\n", total_dirs);
-    if (o_touch)
-      printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
-    else if (o_evict)
-      printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
-    else {
-      printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
-      printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
-      printf("%s  ", pretty_print_size(total_pages*pagesize));
-      if (total_pages)
-        printf("%.3g%%", 100.0*total_pages_in_core/total_pages);
-      printf("\n");
+    if (o_keyvalue) {
+      char pagestr[9];
+      if (o_touch)
+        strcpy(pagestr, "Touched");
+      else if (o_evict)
+        strcpy(pagestr, "Evicted");
+      else 
+        strcpy(pagestr, "Resident");
+      printf("Files=%" PRId64 " Directories=%" PRId64 " %sPages=%" PRId64 " TotalPages=%" PRId64 " %sSize=%" PRId64 " TotalSize=%" PRId64 " %sPercent=%.3g Elapsed=%.5g", total_files, total_dirs, pagestr, total_pages_in_core, total_pages, pagestr, total_pages_in_core*pagesize, total_pages*pagesize, pagestr, 100.0*total_pages_in_core/total_pages, (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
     }
-    printf("         Elapsed: %.5g seconds\n", (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+    else {
+      if (o_verbose) printf("\n");
+      printf("           Files: %" PRId64 "\n", total_files);
+      printf("     Directories: %" PRId64 "\n", total_dirs);
+      if (o_touch)
+        printf("   Touched Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+      else if (o_evict)
+        printf("   Evicted Pages: %" PRId64 " (%s)\n", total_pages, pretty_print_size(total_pages*pagesize));
+      else {
+        printf("  Resident Pages: %" PRId64 "/%" PRId64 "  ", total_pages_in_core, total_pages);
+        printf("%s/", pretty_print_size(total_pages_in_core*pagesize));
+        printf("%s  ", pretty_print_size(total_pages*pagesize));
+        if (total_pages)
+          printf("%.3g%%", 100.0*total_pages_in_core/total_pages);
+        printf("\n");
+      }
+      printf("         Elapsed: %.5g seconds\n", (end_time.tv_sec - start_time.tv_sec) + (double)(end_time.tv_usec - start_time.tv_usec)/1000000.0);
+    }
   }
 
   return 0;


### PR DESCRIPTION
I have the desire to track file cache diagnostics across many machines on regular basis, so having machine-friendly output is a must.  My logging system can parse either KVP or JSON records.

My first attempt used `sed` and `awk`.  KVP is easy to read/write with these tools.

```
$ vmtouch /home/foo | sed -r 's/^  Resident Pages: ([0-9]+)\/([0-9]+)\s\s([0-9\/]+[KMG]?)\/([0-9\/]+[KMG])\s\s([0-9]+)%/   ResidentPages: \1\n      TotalPages: \2\n    ResidentSize: \3\n       TotalSize: \4\n ResidentPercent: \5/g' | sed 's/ seconds//' | awk 'BEGIN { FS = ": "; OFS="="; ORS=" ";} { sub(/^[ \s]+/, ""); print $1,$2}'; echo
```
```
Files=37 Directories=1 ResidentPages=17885956 TotalPages=17885956 ResidentSize=68G TotalSize=68G ResidentPercent=100 Elapsed=0.01825
```

This gets me most of what I want however the size units are a pain to deal with.  I would need to figure out how to get `numfmt`/`units` involved or rewrite in perl or the like.  This was getting complicated quickly.

I realized just adding my own printf inside vmtouch would be much simpler, so here we are.  I realize JSON is the trending format these days, however I just stuck with kvp since it's simpler and it works for me.  

Example output produced by -k switch:
```
Files=37 Directories=1 ResidentPages=17885956 TotalPages=17885956 ResidentSize=73014444032 TotalSize=73014444032 ResidentPercent=100 Elapsed=0.01825
```
